### PR TITLE
Move window to origin

### DIFF
--- a/lib/applitools/selenium/viewport_size.rb
+++ b/lib/applitools/selenium/viewport_size.rb
@@ -117,6 +117,9 @@ class Applitools::Selenium::ViewportSize
   end
 
   def set_browser_size(other)
+    # Before resizing the window, set its position to the upper left corner (otherwise, there might not be enough
+    # "space" below/next to it and the operation won't be successful).
+    @driver.manage.window.position = Selenium::WebDriver::Point.new(0, 0)
     @driver.manage.window.size = other
   end
 


### PR DESCRIPTION
Before resizing the window, set its position to the upper left corner (otherwise, there might not be enough "space" below/next to it and the operation won't be successful).