### PR TITLE
Optimize rotation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in eyes_selenium.gemspec
 gemspec
-
-gem 'oily_png', git: 'git://github.com/applitools/oily_png.git'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in eyes_selenium.gemspec
 gemspec
+
+gem 'oily_png', git: 'git://github.com/applitools/oily_png.git'

--- a/eyes_selenium.gemspec
+++ b/eyes_selenium.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'selenium-webdriver', '>= 2.45.0'
+  spec.add_dependency 'oily_png', '>= 1.2'
   spec.add_dependency 'faraday'
   spec.add_dependency 'oj'
 

--- a/eyes_selenium.gemspec
+++ b/eyes_selenium.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'selenium-webdriver', '>= 2.45.0'
-  spec.add_dependency 'oily_png'
   spec.add_dependency 'faraday'
   spec.add_dependency 'oj'
 

--- a/lib/applitools/utils/image_utils.rb
+++ b/lib/applitools/utils/image_utils.rb
@@ -2,6 +2,8 @@ require 'oily_png'
 require 'base64'
 
 module Applitools::Utils
+  QUADRANTS_COUNT = 4.freeze
+
   module ImageUtils
     extend self
 
@@ -52,9 +54,17 @@ module Applitools::Utils
     #   and negative values are used for counter-clockwise rotation.
     #
     def quadrant_rotate!(image, num_quadrants)
-      image.tap do |img|
-        rotate_method = num_quadrants > 0 ? img.method(:rotate_right!) : img.method(:rotate_left!)
-        (0..(num_quadrants.abs - 1)).each { rotate_method.call }
+      num_quadrants %= QUADRANTS_COUNT
+
+      case num_quadrants
+      when 0
+        image
+      when 1
+        image.rotate_right!
+      when 2
+        image.rotate_180!
+      when 3
+        image.rotate_left!
       end
     end
 


### PR DESCRIPTION
1. Reduce quadrant rotations to only 1 rotation: right, 180, left.
2. Use newer oily_png.

The improvement is by:
- Rotate right: x100
- Rotate 180: x8000
- Rotate left: x300

![image](https://cloud.githubusercontent.com/assets/2841614/7858593/11723942-0542-11e5-90b1-09f8c5a01361.png)