### PR TITLE
Improve the performance of PNG encoding

### DIFF
--- a/lib/applitools/eyes.rb
+++ b/lib/applitools/eyes.rb
@@ -396,7 +396,7 @@ class Applitools::Eyes
     @should_match_window_run_once_on_timeout = true
     return if @session.new_session?
 
-    Applitools::EyesLogger.info %( mismatch #{ tag ? '' : "(#{tag})" } )
+    Applitools::EyesLogger.info %(mismatch #{tag ? '' : "(#{tag})"})
     return unless failure_reports.to_i == Applitools::Eyes::FAILURE_REPORTS[:immediate]
 
     raise Applitools::TestFailedError.new("Mismatch found in '#{@session_start_info.scenario_id_or_name}' "\

--- a/lib/applitools/utils/image_utils.rb
+++ b/lib/applitools/utils/image_utils.rb
@@ -33,7 +33,7 @@ module Applitools::Utils
     # Returns:
     # +String+ The PNG bytes of the image.
     def bytes_from_png_image(image)
-      image.to_blob
+      image.to_blob(:fast_rgb)
     end
 
     # Get the Base64 representation of the raw PNG bytes of an image.

--- a/lib/applitools/version.rb
+++ b/lib/applitools/version.rb
@@ -1,3 +1,3 @@
 module Applitools
-  VERSION = '2.20.0'.freeze
+  VERSION = '2.20.1'.freeze
 end


### PR DESCRIPTION
Use the :fast_rgb schema for image encoding (color: ChunkyPNG::COLOR_TRUECOLOR, compression: Zlib::BEST_SPEED).

This fix improves the running time by a x80 factor.