### PR TITLE
Ensure consistent load order across platforms

### DIFF
--- a/lib/eyes_selenium.rb
+++ b/lib/eyes_selenium.rb
@@ -1,8 +1,8 @@
 module Applitools
   ROOT_DIR = File.join(File.dirname(File.expand_path(__FILE__)), 'applitools').freeze
 
-  Dir["#{ROOT_DIR}/*.rb"].each { |f| require f }
-  Dir["#{ROOT_DIR}/**/*.rb"].each { |f| require f }
+  Dir["#{ROOT_DIR}/*.rb"].sort.each { |f| require f }
+  Dir["#{ROOT_DIR}/**/*.rb"].sort.each { |f| require f }
 
   class EyesError < StandardError; end
   class EyesAbort < EyesError; end


### PR DESCRIPTION
The order in which results are returned from a call to [`Dir[]`](http://ruby-doc.org/core-2.2.2/Dir.html#method-c-5B-5D) is platform-dependent, and therefore unreliable. This PR appends `sort` to the returned arrays to ensure cross-platform consistency in load order, fixing issue #25.