### PR TITLE
Fix Applitools::Selenium::Element equality

### DIFF
--- a/lib/applitools/selenium/element.rb
+++ b/lib/applitools/selenium/element.rb
@@ -25,6 +25,9 @@ module Applitools::Selenium
     end
 
     def ==(other)
+      # If comparing two Applitools::Selenium::Element, compare their wrapped elements
+      return web_element == other.web_element if other.is_a?(self.class)
+
       other.is_a?(web_element.class) && web_element == other
     end
     alias eql? ==

--- a/spec/driver_passthrough_spec.rb
+++ b/spec/driver_passthrough_spec.rb
@@ -37,6 +37,16 @@ describe 'passthrough methods' do
         expect(link).not_to be_nil
         expect(link).to be_a(Applitools::Selenium::Element)
       end
+
+      # From the Selenium tests
+      # @see https://github.com/SeleniumHQ/selenium/blob/7e2cca5/rb/spec/integration/selenium/webdriver/element_spec.rb#L192
+      it 'should know when two elements are equal' do
+        body = @driver.find_element(tag_name: 'body')
+        xbody = @driver.find_element(xpath: '//body')
+
+        expect(body).to eq(xbody)
+        expect(body).to eql(xbody)
+      end
     end
 
     context 'all elements' do


### PR DESCRIPTION
The wrapper class `Applitools::Selenium::Element`'s equality function does not match the behavior of `Selenium::Webdriver::Element`, which it is supposed to transparently wrap.  In particular, it violates this test:

_[From selenium/webdriver/element_spec.rb](https://github.com/SeleniumHQ/selenium/blob/7e2cca5/rb/spec/integration/selenium/webdriver/element_spec.rb#L192)_
```ruby
      it 'should know when two elements are equal' do
        driver.navigate.to url_for('simpleTest.html')

        body = driver.find_element(tag_name: 'body')
        xbody = driver.find_element(xpath: '//body')

        expect(body).to eq(xbody)
        expect(body).to eql(xbody)
      end
```

I've added this test to the driver passthrough spec and fixed it by adding support for comparing two `Applitools::Selenium::Element`s to one another, which was not previously possible.