### PR TITLE
Base Poltergeist support

### DIFF
--- a/eyes_selenium.gemspec
+++ b/eyes_selenium.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'selenium-webdriver', '>= 2.45.0'
+  spec.add_dependency 'poltergeist', '~> 1.9'
   spec.add_dependency 'oily_png', '~> 1.2'
   spec.add_dependency 'chunky_png', '= 1.3.6'
   spec.add_dependency 'faraday'

--- a/lib/applitools/eyes.rb
+++ b/lib/applitools/eyes.rb
@@ -1,3 +1,5 @@
+require 'capybara/poltergeist'
+
 require_relative 'version'
 require_relative 'eyes_logger'
 
@@ -146,7 +148,7 @@ class Applitools::Eyes
         @driver = case driver
         when Selenium::WebDriver
           Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
-        when Capybara::Poltergeist::Driver
+        when Capybara::Poltergeist::Driver # driver for PhantomJS
           Applitools::Poltergeist::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
         else
           Applitools::EyesLogger.warn("Unrecognized driver type: (#{driver.class.name})!")

--- a/lib/applitools/eyes.rb
+++ b/lib/applitools/eyes.rb
@@ -145,15 +145,16 @@ class Applitools::Eyes
       unless driver.is_a?(Applitools::Selenium::Driver)
         is_mobile_device = driver.respond_to?(:capabilities) && driver.capabilities['platformName']
 
-        @driver = case driver
-        when Selenium::WebDriver
-          Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
-        when Capybara::Poltergeist::Driver # driver for PhantomJS
-          Applitools::Poltergeist::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
-        else
-          Applitools::EyesLogger.warn("Unrecognized driver type: (#{driver.class.name})!")
-          Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
-        end
+        @driver =
+          case driver
+          when Selenium::WebDriver
+            Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+          when Capybara::Poltergeist::Driver # driver for PhantomJS
+            Applitools::Poltergeist::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+          else
+            Applitools::EyesLogger.warn("Unrecognized driver type: (#{driver.class.name})!")
+            Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+          end
 
       end
     end

--- a/lib/applitools/eyes.rb
+++ b/lib/applitools/eyes.rb
@@ -141,10 +141,18 @@ class Applitools::Eyes
       @driver = driver.driver_for_eyes self
     else
       unless driver.is_a?(Applitools::Selenium::Driver)
-        Applitools::EyesLogger.warn("Unrecognized driver type: (#{driver.class.name})!") unless
-            driver.is_a? Selenium::WebDriver
         is_mobile_device = driver.respond_to?(:capabilities) && driver.capabilities['platformName']
-        @driver = Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+
+        @driver = case driver
+        when Selenium::WebDriver
+          Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+        when Capybara::Poltergeist::Driver
+          Applitools::Poltergeist::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+        else
+          Applitools::EyesLogger.warn("Unrecognized driver type: (#{driver.class.name})!")
+          Applitools::Selenium::Driver.new(self, driver: driver, is_mobile_device: is_mobile_device)
+        end
+
       end
     end
 

--- a/lib/applitools/poltergeist/applitools_compatible.rb
+++ b/lib/applitools/poltergeist/applitools_compatible.rb
@@ -1,0 +1,20 @@
+module Applitools::Poltergeist
+  module ApplitoolsCompatible
+    def screenshot_as(fmt)
+      Base64.decode64(browser.render_base64(fmt))
+    end
+
+    def manage
+      self
+    end
+
+    def window
+      self
+    end
+
+    def size
+      size = window_size(current_window_handle)
+      Applitools::Base::Dimension.new(size[0], size[1])
+    end
+  end
+end

--- a/lib/applitools/poltergeist/applitools_compatible.rb
+++ b/lib/applitools/poltergeist/applitools_compatible.rb
@@ -1,17 +1,21 @@
+# This module is used for compatibility with Applitools API.
+# Should be extended by Poltergeist driver instance.
 module Applitools::Poltergeist
   module ApplitoolsCompatible
+
+    # Implementation of `screenshot_as` method for PhantomJS.
+    # Realisation uses Poltergeist binding to `renderBase64` PhantomJS method.
     def screenshot_as(fmt)
       Base64.decode64(browser.render_base64(fmt))
     end
 
-    def manage
-      self
+    # Poltergeist driver does not have `manage` and `window` methods.
+    # In Applitools these methods are used in a chain to get size by `size` method call.
+    ['manage', 'window'].each do |method_name|
+      define_method(method_name) { self }
     end
 
-    def window
-      self
-    end
-
+    # Method provides opened window size in Applitools format.
     def size
       size = window_size(current_window_handle)
       Applitools::Base::Dimension.new(size[0], size[1])

--- a/lib/applitools/poltergeist/applitools_compatible.rb
+++ b/lib/applitools/poltergeist/applitools_compatible.rb
@@ -20,5 +20,10 @@ module Applitools::Poltergeist
       size = window_size(current_window_handle)
       Applitools::Base::Dimension.new(size[0], size[1])
     end
+
+    # Method changes opened window size in a way how original Applitools::Selenium::Driver does.
+    def size=(new_size)
+      resize(new_size.width, new_size.height)
+    end
   end
 end

--- a/lib/applitools/poltergeist/applitools_compatible.rb
+++ b/lib/applitools/poltergeist/applitools_compatible.rb
@@ -2,7 +2,6 @@
 # Should be extended by Poltergeist driver instance.
 module Applitools::Poltergeist
   module ApplitoolsCompatible
-
     # Implementation of `screenshot_as` method for PhantomJS.
     # Realisation uses Poltergeist binding to `renderBase64` PhantomJS method.
     def screenshot_as(fmt)
@@ -11,7 +10,7 @@ module Applitools::Poltergeist
 
     # Poltergeist driver does not have `manage` and `window` methods.
     # In Applitools these methods are used in a chain to get size by `size` method call.
-    ['manage', 'window'].each do |method_name|
+    %w(manage window).each do |method_name|
       define_method(method_name) { self }
     end
 

--- a/lib/applitools/poltergeist/driver.rb
+++ b/lib/applitools/poltergeist/driver.rb
@@ -1,0 +1,10 @@
+require 'capybara/poltergeist'
+
+module Applitools::Poltergeist
+  class Driver < Applitools::Selenium::Driver
+    def initialize(eyes, options)
+      options[:driver].extend Applitools::Poltergeist::ApplitoolsCompatible
+      super(eyes, options)
+    end
+  end
+end

--- a/lib/applitools/poltergeist/driver.rb
+++ b/lib/applitools/poltergeist/driver.rb
@@ -1,5 +1,6 @@
-require 'capybara/poltergeist'
-
+# Applitools::Poltergeist::Driver is a small class implemented
+# for compatibility with Applitools API.
+# It gives required for Applitools methods to Poltergeist driver.
 module Applitools::Poltergeist
   class Driver < Applitools::Selenium::Driver
     def initialize(eyes, options)

--- a/lib/eyes_selenium.rb
+++ b/lib/eyes_selenium.rb
@@ -30,6 +30,7 @@ require_relative 'applitools/version'
 Applitools.require_dir 'base'
 Applitools.require_dir 'utils'
 Applitools.require_dir 'selenium'
+Applitools.require_dir 'poltergeist'
 
 require_relative 'applitools/eyes'
 require_relative 'applitools/selenium_webdriver'


### PR DESCRIPTION
Added support for Poltergeist driver. 

This feature implements methods required for work with Applitools API. As both original (`Applitools::Selenium::Driver` and `Poltegeist::Driver`) drivers have slight differences it is easy to add missing parts than rewrite the driver from scratch.